### PR TITLE
add sqllite_db to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -127,3 +127,5 @@ dmypy.json
 
 # Pyre type checker
 .pyre/
+
+sqlite_db 


### PR DESCRIPTION
sqllite_db is a mysql temporary database until we set up the sqlalchemy version. This file changes between computers as it is not in human language when the app is run and therefor can be ignored